### PR TITLE
feat: implement ObjectClassNameResolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
     },
     "require-dev": {
         "bnf/phpstan-psr-container": "^1.0",
+        "doctrine/common": "^3.5",
         "doctrine/doctrine-bundle": "^2.10",
         "ekino/phpstan-banned-code": "^3.0",
         "league/flysystem-memory": "^3.16",

--- a/packages/file-association/src/Contracts/ObjectClassNameResolverInterface.php
+++ b/packages/file-association/src/Contracts/ObjectClassNameResolverInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Association\Contracts;
+
+use Rekalogika\File\Association\Exception\ObjectClassNameResolver\ObjectClassNameResolverException;
+
+/**
+ * Determines the class name of an object
+ *
+ * @throws ObjectClassNameResolverException
+ */
+interface ObjectClassNameResolverInterface
+{
+    public function getObjectClassName(object $object): string;
+}

--- a/packages/file-association/src/Exception/ObjectClassNameResolver/ChainedObjectClassNameResolverException.php
+++ b/packages/file-association/src/Exception/ObjectClassNameResolver/ChainedObjectClassNameResolverException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Association\Exception\ObjectClassNameResolver;
+
+final class ChainedObjectClassNameResolverException extends ObjectClassNameResolverException
+{
+    /**
+     * @param iterable<ObjectClassNameResolverException> $exceptions
+     */
+    public function __construct(
+        object $object,
+        private readonly iterable $exceptions,
+        ?\Throwable $previous = null,
+    ) {
+        \Exception::__construct(
+            \sprintf(
+                'None of the object class name resolvers registered in the system supports the object "%s"',
+                $object::class,
+            ),
+            0,
+            $previous,
+        );
+    }
+
+    /**
+     * @return iterable<ObjectClassNameResolverException>
+     */
+    public function getExceptions(): iterable
+    {
+        return $this->exceptions;
+    }
+}

--- a/packages/file-association/src/Exception/ObjectClassNameResolver/ObjectClassNameResolverException.php
+++ b/packages/file-association/src/Exception/ObjectClassNameResolver/ObjectClassNameResolverException.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Association\Exception\ObjectClassNameResolver;
+
+use Rekalogika\File\Association\Exception\FileAssociationException;
+
+class ObjectClassNameResolverException extends FileAssociationException {}

--- a/packages/file-association/src/FileLocationResolver/DefaultFileLocationResolver.php
+++ b/packages/file-association/src/FileLocationResolver/DefaultFileLocationResolver.php
@@ -15,12 +15,14 @@ namespace Rekalogika\File\Association\FileLocationResolver;
 
 use Rekalogika\Contracts\File\FilePointerInterface;
 use Rekalogika\File\Association\Contracts\FileLocationResolverInterface;
+use Rekalogika\File\Association\Contracts\ObjectClassNameResolverInterface;
 use Rekalogika\File\Association\Contracts\ObjectIdResolverInterface;
 use Rekalogika\File\Association\Model\FilePointer;
 
 final class DefaultFileLocationResolver implements FileLocationResolverInterface
 {
     public function __construct(
+        private readonly ObjectClassNameResolverInterface $objectClassNameResolver,
         private readonly ObjectIdResolverInterface $objectIdResolver,
         private readonly string $filesystemIdentifier = 'default',
         private readonly string $prefix = 'entity',
@@ -32,12 +34,13 @@ final class DefaultFileLocationResolver implements FileLocationResolverInterface
         object $object,
         string $propertyName,
     ): FilePointerInterface {
+        $className = $this->objectClassNameResolver->getObjectClassName($object);
         $id = $this->objectIdResolver->getObjectId($object);
 
         $splittedHash = str_split(sha1($id), 2);
         $hash = implode('/', \array_slice($splittedHash, 0, $this->hashLevel));
 
-        $classHash = sha1($object::class);
+        $classHash = sha1($className);
 
         $key = \sprintf(
             '%s/%s/%s/%s/%s',

--- a/packages/file-association/src/ObjectClassNameResolver/ChainedObjectClassNameResolver.php
+++ b/packages/file-association/src/ObjectClassNameResolver/ChainedObjectClassNameResolver.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Association\ObjectClassNameResolver;
+
+use Rekalogika\File\Association\Contracts\ObjectClassNameResolverInterface;
+use Rekalogika\File\Association\Exception\ObjectClassNameResolver\ChainedObjectClassNameResolverException;
+use Rekalogika\File\Association\Exception\ObjectClassNameResolver\ObjectClassNameResolverException;
+
+final class ChainedObjectClassNameResolver implements ObjectClassNameResolverInterface
+{
+    /**
+     * @var \WeakMap<object,string>
+     */
+    private \WeakMap $cache;
+
+    /**
+     * @param iterable<ObjectClassNameResolverInterface> $objectClassNameResolvers
+     */
+    public function __construct(
+        private readonly iterable $objectClassNameResolvers,
+    ) {
+        /** @var \WeakMap<object,string> */
+        $map = new \WeakMap();
+
+        $this->cache = $map;
+    }
+
+    #[\Override]
+    public function getObjectClassName(object $object): string
+    {
+        if (isset($this->cache[$object])) {
+            /** @var string */
+            return $this->cache[$object];
+        }
+
+        $exceptions = [];
+
+        foreach ($this->objectClassNameResolvers as $objectClassNameResolver) {
+            try {
+                return $this->cache[$object]
+                    = $objectClassNameResolver->getObjectClassName($object);
+            } catch (ObjectClassNameResolverException $e) {
+                $exceptions[] = $e;
+            }
+        }
+
+        throw new ChainedObjectClassNameResolverException($object, $exceptions);
+    }
+}

--- a/packages/file-association/src/ObjectClassNameResolver/DefaultObjectClassNameResolver.php
+++ b/packages/file-association/src/ObjectClassNameResolver/DefaultObjectClassNameResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Association\ObjectClassNameResolver;
+
+use Rekalogika\File\Association\Contracts\ObjectClassNameResolverInterface;
+
+final class DefaultObjectClassNameResolver implements ObjectClassNameResolverInterface
+{
+    #[\Override]
+    public function getObjectClassName(object $object): string
+    {
+        return $object::class;
+    }
+}

--- a/packages/file-association/src/ObjectClassNameResolver/DoctrineObjectClassNameResolver.php
+++ b/packages/file-association/src/ObjectClassNameResolver/DoctrineObjectClassNameResolver.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Association\ObjectClassNameResolver;
+
+use Doctrine\Common\Util\ClassUtils;
+use Rekalogika\File\Association\Contracts\ObjectClassNameResolverInterface;
+
+final class DoctrineObjectClassNameResolver implements ObjectClassNameResolverInterface
+{
+    #[\Override]
+    public function getObjectClassName(object $object): string
+    {
+        return ClassUtils::getClass($object);
+    }
+}

--- a/tests/src/Tests/FileAssociation/DefaultFileLocationResolverTest.php
+++ b/tests/src/Tests/FileAssociation/DefaultFileLocationResolverTest.php
@@ -15,6 +15,7 @@ namespace Rekalogika\File\Tests\Tests\FileAssociation;
 
 use PHPUnit\Framework\TestCase;
 use Rekalogika\File\Association\FileLocationResolver\DefaultFileLocationResolver;
+use Rekalogika\File\Association\ObjectClassNameResolver\DefaultObjectClassNameResolver;
 use Rekalogika\File\Association\ObjectIdResolver\DefaultObjectIdResolver;
 use Rekalogika\File\Tests\Tests\Model\Entity;
 
@@ -22,8 +23,9 @@ final class DefaultFileLocationResolverTest extends TestCase
 {
     public function testDefaultLocationResolver(): void
     {
+        $objectClassNameResolver = new DefaultObjectClassNameResolver();
         $objectIdResolver = new DefaultObjectIdResolver();
-        $locationResolver = new DefaultFileLocationResolver($objectIdResolver);
+        $locationResolver = new DefaultFileLocationResolver($objectClassNameResolver, $objectIdResolver);
         $object = new Entity('entity_id');
 
         $location = $locationResolver->getFileLocation($object, 'file');

--- a/tests/src/Tests/FileAssociation/ObjectClassNameResolverTest.php
+++ b/tests/src/Tests/FileAssociation/ObjectClassNameResolverTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of rekalogika/file-src package.
+ *
+ * (c) Priyadi Iman Nurcahyo <https://rekalogika.dev>
+ *
+ * For the full copyright and license information, please view the LICENSE file
+ * that was distributed with this source code.
+ */
+
+namespace Rekalogika\File\Tests\Tests\FileAssociation;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Rekalogika\File\Association\ObjectClassNameResolver\DefaultObjectClassNameResolver;
+use Rekalogika\File\Association\ObjectClassNameResolver\DoctrineObjectClassNameResolver;
+use Rekalogika\File\Tests\App\Entity\User;
+
+final class ObjectClassNameResolverTest extends DoctrineTestCase
+{
+    public function testDefaultObjectClassNameResolver(): void
+    {
+        $objectClassNameResolver = new DefaultObjectClassNameResolver();
+        $entity = new User('foo');
+
+        $resolvedClassName = $objectClassNameResolver->getObjectClassName($entity);
+        $this->assertSame(User::class, $resolvedClassName);
+    }
+
+    public function testDoctrineProxyObjectClassNameResolver(): void
+    {
+        $entityManager = static::getContainer()->get('doctrine.orm.entity_manager');
+        $this->assertInstanceOf(EntityManagerInterface::class, $entityManager);
+
+        $entityClass = User::class;
+        $entityProxy = $entityManager->getReference($entityClass, 123);
+        $this->assertNotNull($entityProxy);
+        $this->assertNotSame($entityClass, $entityProxy::class);
+
+        $doctrineObjectClassNameResolver = new DoctrineObjectClassNameResolver();
+        $resolvedClassName = $doctrineObjectClassNameResolver->getObjectClassName($entityProxy);
+
+        $this->assertSame($entityClass, $resolvedClassName);
+    }
+}


### PR DESCRIPTION
This allows us to resolve the class name for Doctrine Reference Proxy objects, fixes #88

https://www.doctrine-project.org/projects/doctrine-orm/en/3.3/reference/advanced-configuration.html#reference-proxies